### PR TITLE
Fix/generate docs issues

### DIFF
--- a/src/stub-gen/generator.ts
+++ b/src/stub-gen/generator.ts
@@ -146,7 +146,7 @@ function generateDocParam(name: string, p: IDocParam) {
             code += `${_LT(p.type)}`;
         }
 
-        if (p.nullable) {
+        if (p.nullable || p.default) {
             code += '|nil';
         }
     }

--- a/src/stub-gen/generator.ts
+++ b/src/stub-gen/generator.ts
@@ -108,9 +108,9 @@ function generateDocProperty(name: string, p: IDocProperty, comments?: string[])
     } else if (p.table) {
         code += `${_LT(p.type)}[]`; // Lua table
     } else if (p.nestedArray) {
-        // TODO: Implement
+        code += `vector|table<integer, vector|${_LT(p.type)}[]>`; // nestedArray
     } else if (p.nestedTable) {
-        // TODO: Implement
+        code += `table<integer, vector|${_LT(p.type)}[]>`; // nestedTable
     } else {
         code += `${_LT(p.type)}`;
     }

--- a/src/stub-gen/generator.ts
+++ b/src/stub-gen/generator.ts
@@ -178,9 +178,9 @@ function generateDocReturn(returns: IDocType | IDocType[], comments?: string[]) 
         } else if (r.table) {
             code += `${_LT(r.type)}[]`; // Lua table
         } else if (r.nestedArray) {
-            code += `vector|table<integer, vector|${_LT(p.type)}[]>`; // nestedArray
+            code += `vector|table<integer, vector|${_LT(r.type)}[]>`; // nestedArray
         } else if (r.nestedTable) {
-            code += `table<integer, vector|${_LT(p.type)}[]>`; // nestedTable
+            code += `table<integer, vector|${_LT(r.type)}[]>`; // nestedTable
         } else {
             code += `${_LT(r.type)}`;
         }

--- a/src/stub-gen/generator.ts
+++ b/src/stub-gen/generator.ts
@@ -139,9 +139,9 @@ function generateDocParam(name: string, p: IDocParam) {
         } else if (p.table) {
             code += `${_LT(p.type)}[]`; // Lua table
         } else if (p.nestedArray) {
-            // TODO: Implement
+            code += `vector|table<integer, vector|${_LT(p.type)}[]>`; // nestedArray
         } else if (p.nestedTable) {
-            // TODO: Implement
+            code += `table<integer, vector|${_LT(p.type)}[]>`; // nestedTable
         } else {
             code += `${_LT(p.type)}`;
         }
@@ -178,9 +178,9 @@ function generateDocReturn(returns: IDocType | IDocType[], comments?: string[]) 
         } else if (r.table) {
             code += `${_LT(r.type)}[]`; // Lua table
         } else if (r.nestedArray) {
-            // TODO: Implement
+            code += `vector|table<integer, vector|${_LT(p.type)}[]>`; // nestedArray
         } else if (r.nestedTable) {
-            // TODO: Implement
+            code += `table<integer, vector|${_LT(p.type)}[]>`; // nestedTable
         } else {
             code += `${_LT(r.type)}`;
         }


### PR DESCRIPTION
- #21 
- handle default parameters also as nullable | example: `Guid(guid: string, format: string='D')`
Right now `Guid("76BEB44D-6B4F-2336-C4B6-7145A294B02F")` would cause a warning, because the lua extension thinks that Guid takes 2 params.